### PR TITLE
Fix an issue where txt file would not be created if text archives fails to be read

### DIFF
--- a/DS_Map/ROMFiles/TextArchive.cs
+++ b/DS_Map/ROMFiles/TextArchive.cs
@@ -239,6 +239,10 @@ namespace DSPRE.ROMFiles
                     messages = TextConverter.ReadMessageFromStream(fs, out key);
                     fs.Close();
                 }
+
+                // Create the .txt file for future use
+                SaveToExpandedDir(ID, false);
+
                 return true;
             }
             catch (Exception ex)


### PR DESCRIPTION
When encountering an invalid textarchive .txt the bin file was read but .txt file was created requiring the process to be repeated again. This should now be resolved.