### PR TITLE
Fix and Add Text in PokeFacts.txt

### DIFF
--- a/DS_Map/Tools/pokefatcs.txt
+++ b/DS_Map/Tools/pokefatcs.txt
@@ -135,4 +135,7 @@ Pryce claims that the Glacier Badge will increase the Special stats of Pokémon.
 Professor Elm is known for research into Pokémon Eggs, but Professor Oak calls him an expert in Evolution!
 Solar-powered Sunflora rushes about in the daylight, then closes its petals and stops completely at sunset.
 Shuckie the Shuckle was one of a Cianwood City PokeManiac's two rare Pokémon, but the other was stolen by Silver!
+The only Pokémon with higher Defense and Special Defense stats than Shuckle, is Eternamax Eternatus!
+Shuckle's base stats are the most uneven of all Pokémon, measured by standard deviation.
 In Pokémon Gold & Silver, Shuckle will sometimes turn a held berry into Berry Juice!
+It's theorised that a Shuckle-Regigigas hybrid could vie with Arceus for supremecy.


### PR DESCRIPTION
Some of the text was messed up grammatically and/or had other issues, such as the accented e's being missing in Pokémon (the preview on Github shows the accented e incorrectly, but I confirmed in DSPRE that they show up properly). I also added text about the other regions by generation 4 since Sinnoh isn't the only one that existed by that time, and updated text like "in Platinum" to not specify the game since there are multiple games with Sinnoh in them.
Also, lol, you should update the file name from pokefatcs.txt.