### PR TITLE
fix wrong flytable reading with decomp definitions, closes #9

### DIFF
--- a/DS_Map/FlyEditor/Data/FlyTableRowHgss.cs
+++ b/DS_Map/FlyEditor/Data/FlyTableRowHgss.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -10,9 +10,14 @@ namespace DSPRE.Editors.Data
     {
         public FlyTableRowHgss() { }
 
-        public FlyTableRowHgss(ushort headerIdGameOver, byte localX, byte localY, ushort headerIdFly, ushort globalX, ushort globalY,
-                               ushort headerIdUnlockWarp, ushort globalXUnlock, ushort globalYUnlock, byte unlockId, byte warpCondition)
+        public FlyTableRowHgss(byte flagIdx, bool isBlackoutSpawn, bool isFlyPoint,
+                               ushort headerIdGameOver, byte localX, byte localY,
+                               ushort headerIdFly, ushort globalX, ushort globalY,
+                               ushort headerIdUnlockWarp, ushort globalXUnlock, ushort globalYUnlock)
         {
+            FlagIdx = flagIdx;
+            IsBlackoutSpawn = isBlackoutSpawn;
+            IsFlyPoint = isFlyPoint;
             HeaderIdGameOver = headerIdGameOver;
             LocalX = localX;
             LocalY = localY;
@@ -22,21 +27,19 @@ namespace DSPRE.Editors.Data
             HeaderIdUnlockWarp = headerIdUnlockWarp;
             GlobalXUnlock = globalXUnlock;
             GlobalYUnlock = globalYUnlock;
-            UnlockId = unlockId;
-            WarpCondition = warpCondition;
         }
 
-        public ushort GlobalX { get; set; }
-        public ushort GlobalXUnlock { get; set; }
-        public ushort GlobalY { get; set; }
-        public ushort GlobalYUnlock { get; set; }
-        public ushort HeaderIdFly { get; set; }
+        public byte FlagIdx { get; set; }
+        public bool IsBlackoutSpawn { get; set; }
+        public bool IsFlyPoint { get; set; }
         public ushort HeaderIdGameOver { get; set; }
-        public ushort HeaderIdUnlockWarp { get; set; }
         public byte LocalX { get; set; }
-        public byte LocalY { get; set; }                 
-        public byte UnlockId { get; set; }                
-        public byte WarpCondition { get; set; }         
+        public byte LocalY { get; set; }
+        public ushort HeaderIdFly { get; set; }
+        public ushort GlobalX { get; set; }
+        public ushort GlobalY { get; set; }
+        public ushort HeaderIdUnlockWarp { get; set; }
+        public ushort GlobalXUnlock { get; set; }
+        public ushort GlobalYUnlock { get; set; }
     }
-
 }


### PR DESCRIPTION
our reading of the table was offset by 2 bytes and was reading the flag id for the next entry, also the warpCondition was actually a bitmap for "is blackout spawn" and "is fly point" flags