### PR TITLE
Add bug contest editor to special encounters

### DIFF
--- a/DS_Map/DSPRE.csproj
+++ b/DS_Map/DSPRE.csproj
@@ -113,6 +113,12 @@
     <Compile Include="DSUtils\OverlayUtils.cs" />
     <Compile Include="DSUtils\TextConverter.cs" />
     <Compile Include="DSUtils\YamlUtils.cs" />
+    <Compile Include="Editors\BugContestEncounterEditor.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Editors\BugContestEncounterEditor.Designer.cs">
+      <DependentUpon>BugContestEncounterEditor.cs</DependentUpon>
+    </Compile>
     <Compile Include="Editors\EggMoveEditor.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -409,6 +415,7 @@
     <Compile Include="OffsetPictureBox.cs">
       <SubType>Component</SubType>
     </Compile>
+    <Compile Include="ROMFiles\BugContestEncounterFile.cs" />
     <Compile Include="ROMFiles\EvolutionFile.cs" />
     <Compile Include="ROMFiles\HeadbuttEncounter.cs" />
     <Compile Include="ROMFiles\HeadbuttEncounterFile.cs" />
@@ -557,6 +564,9 @@
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\writeText.Designer.cs" />
+    <EmbeddedResource Include="Editors\BugContestEncounterEditor.resx">
+      <DependentUpon>BugContestEncounterEditor.cs</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="Editors\EggMoveEditor.resx">
       <DependentUpon>EggMoveEditor.cs</DependentUpon>
     </EmbeddedResource>

--- a/DS_Map/Editors/BugContestEncounterEditor.Designer.cs
+++ b/DS_Map/Editors/BugContestEncounterEditor.Designer.cs
@@ -1,0 +1,487 @@
+namespace DSPRE.Editors {
+    partial class BugContestEncounterEditor {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing) {
+            if (disposing && (components != null)) {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        private void InitializeComponent() {
+            this.components = new System.ComponentModel.Container();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(BugContestEncounterEditor));
+            this.labelNotAvailable = new System.Windows.Forms.Label();
+            this.panelMain = new System.Windows.Forms.Panel();
+            this.groupBoxInfo = new System.Windows.Forms.GroupBox();
+            this.labelInfo = new System.Windows.Forms.Label();
+            this.groupBoxSet = new System.Windows.Forms.GroupBox();
+            this.comboBoxSet = new System.Windows.Forms.ComboBox();
+            this.labelSetDescription = new System.Windows.Forms.Label();
+            this.groupBoxEncounters = new System.Windows.Forms.GroupBox();
+            this.listBoxEncounters = new System.Windows.Forms.ListBox();
+            this.buttonAdd = new System.Windows.Forms.Button();
+            this.buttonRemove = new System.Windows.Forms.Button();
+            this.groupBoxDetails = new System.Windows.Forms.GroupBox();
+            this.pictureBoxPokemon = new System.Windows.Forms.PictureBox();
+            this.labelSpecies = new System.Windows.Forms.Label();
+            this.comboBoxSpecies = new System.Windows.Forms.ComboBox();
+            this.labelMinLevel = new System.Windows.Forms.Label();
+            this.numericUpDownMinLevel = new System.Windows.Forms.NumericUpDown();
+            this.labelMaxLevel = new System.Windows.Forms.Label();
+            this.numericUpDownMaxLevel = new System.Windows.Forms.NumericUpDown();
+            this.labelRate = new System.Windows.Forms.Label();
+            this.numericUpDownRate = new System.Windows.Forms.NumericUpDown();
+            this.labelScore = new System.Windows.Forms.Label();
+            this.numericUpDownScore = new System.Windows.Forms.NumericUpDown();
+            this.labelDummy = new System.Windows.Forms.Label();
+            this.numericUpDownDummy = new System.Windows.Forms.NumericUpDown();
+            this.labelDummyInfo = new System.Windows.Forms.Label();
+            this.buttonSave = new System.Windows.Forms.Button();
+            this.buttonExport = new System.Windows.Forms.Button();
+            this.buttonImport = new System.Windows.Forms.Button();
+            this.buttonLocate = new System.Windows.Forms.Button();
+            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.panelMain.SuspendLayout();
+            this.groupBoxInfo.SuspendLayout();
+            this.groupBoxSet.SuspendLayout();
+            this.groupBoxEncounters.SuspendLayout();
+            this.groupBoxDetails.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxPokemon)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinLevel)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxLevel)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownRate)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownScore)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownDummy)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // labelNotAvailable
+            // 
+            this.labelNotAvailable.AutoSize = true;
+            this.labelNotAvailable.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F);
+            this.labelNotAvailable.Location = new System.Drawing.Point(20, 20);
+            this.labelNotAvailable.Name = "labelNotAvailable";
+            this.labelNotAvailable.Size = new System.Drawing.Size(334, 20);
+            this.labelNotAvailable.TabIndex = 0;
+            this.labelNotAvailable.Text = "Bug Contest Editor is only available for HGSS.";
+            this.labelNotAvailable.Visible = false;
+            // 
+            // panelMain
+            // 
+            this.panelMain.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.panelMain.Controls.Add(this.groupBoxInfo);
+            this.panelMain.Controls.Add(this.groupBoxSet);
+            this.panelMain.Controls.Add(this.groupBoxEncounters);
+            this.panelMain.Controls.Add(this.groupBoxDetails);
+            this.panelMain.Controls.Add(this.buttonSave);
+            this.panelMain.Controls.Add(this.buttonExport);
+            this.panelMain.Controls.Add(this.buttonImport);
+            this.panelMain.Controls.Add(this.buttonLocate);
+            this.panelMain.Location = new System.Drawing.Point(3, 3);
+            this.panelMain.Name = "panelMain";
+            this.panelMain.Size = new System.Drawing.Size(847, 558);
+            this.panelMain.TabIndex = 1;
+            // 
+            // groupBoxInfo
+            // 
+            this.groupBoxInfo.Controls.Add(this.labelInfo);
+            this.groupBoxInfo.Location = new System.Drawing.Point(312, 282);
+            this.groupBoxInfo.Name = "groupBoxInfo";
+            this.groupBoxInfo.Size = new System.Drawing.Size(376, 257);
+            this.groupBoxInfo.TabIndex = 7;
+            this.groupBoxInfo.TabStop = false;
+            this.groupBoxInfo.Text = "Information";
+            // 
+            // labelInfo
+            // 
+            this.labelInfo.Location = new System.Drawing.Point(6, 16);
+            this.labelInfo.Name = "labelInfo";
+            this.labelInfo.Size = new System.Drawing.Size(364, 182);
+            this.labelInfo.TabIndex = 0;
+            this.labelInfo.Text = resources.GetString("labelInfo.Text");
+            // 
+            // groupBoxSet
+            // 
+            this.groupBoxSet.Controls.Add(this.comboBoxSet);
+            this.groupBoxSet.Controls.Add(this.labelSetDescription);
+            this.groupBoxSet.Location = new System.Drawing.Point(6, 6);
+            this.groupBoxSet.Name = "groupBoxSet";
+            this.groupBoxSet.Size = new System.Drawing.Size(300, 90);
+            this.groupBoxSet.TabIndex = 0;
+            this.groupBoxSet.TabStop = false;
+            this.groupBoxSet.Text = "Encounter Set";
+            // 
+            // comboBoxSet
+            // 
+            this.comboBoxSet.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSet.FormattingEnabled = true;
+            this.comboBoxSet.Location = new System.Drawing.Point(6, 19);
+            this.comboBoxSet.Name = "comboBoxSet";
+            this.comboBoxSet.Size = new System.Drawing.Size(288, 21);
+            this.comboBoxSet.TabIndex = 0;
+            this.comboBoxSet.SelectedIndexChanged += new System.EventHandler(this.comboBoxSet_SelectedIndexChanged);
+            // 
+            // labelSetDescription
+            // 
+            this.labelSetDescription.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.labelSetDescription.Location = new System.Drawing.Point(6, 45);
+            this.labelSetDescription.Name = "labelSetDescription";
+            this.labelSetDescription.Size = new System.Drawing.Size(288, 40);
+            this.labelSetDescription.TabIndex = 1;
+            this.labelSetDescription.Text = "Select a set to view encounters";
+            // 
+            // groupBoxEncounters
+            // 
+            this.groupBoxEncounters.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left)));
+            this.groupBoxEncounters.Controls.Add(this.listBoxEncounters);
+            this.groupBoxEncounters.Controls.Add(this.buttonAdd);
+            this.groupBoxEncounters.Controls.Add(this.buttonRemove);
+            this.groupBoxEncounters.Location = new System.Drawing.Point(6, 102);
+            this.groupBoxEncounters.Name = "groupBoxEncounters";
+            this.groupBoxEncounters.Size = new System.Drawing.Size(300, 443);
+            this.groupBoxEncounters.TabIndex = 1;
+            this.groupBoxEncounters.TabStop = false;
+            this.groupBoxEncounters.Text = "Encounters (10 per set)";
+            // 
+            // listBoxEncounters
+            // 
+            this.listBoxEncounters.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.listBoxEncounters.FormattingEnabled = true;
+            this.listBoxEncounters.Location = new System.Drawing.Point(6, 19);
+            this.listBoxEncounters.Name = "listBoxEncounters";
+            this.listBoxEncounters.Size = new System.Drawing.Size(288, 368);
+            this.listBoxEncounters.TabIndex = 0;
+            this.listBoxEncounters.SelectedIndexChanged += new System.EventHandler(this.listBoxEncounters_SelectedIndexChanged);
+            // 
+            // buttonAdd
+            // 
+            this.buttonAdd.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonAdd.Enabled = false;
+            this.buttonAdd.Image = global::DSPRE.Properties.Resources.addIcon;
+            this.buttonAdd.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonAdd.Location = new System.Drawing.Point(6, 405);
+            this.buttonAdd.Name = "buttonAdd";
+            this.buttonAdd.Size = new System.Drawing.Size(138, 32);
+            this.buttonAdd.TabIndex = 1;
+            this.buttonAdd.Text = "Add";
+            this.buttonAdd.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonAdd.UseVisualStyleBackColor = true;
+            // 
+            // buttonRemove
+            // 
+            this.buttonRemove.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.buttonRemove.Enabled = false;
+            this.buttonRemove.Image = global::DSPRE.Properties.Resources.deleteIcon;
+            this.buttonRemove.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonRemove.Location = new System.Drawing.Point(156, 405);
+            this.buttonRemove.Name = "buttonRemove";
+            this.buttonRemove.Size = new System.Drawing.Size(138, 32);
+            this.buttonRemove.TabIndex = 2;
+            this.buttonRemove.Text = "Remove";
+            this.buttonRemove.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonRemove.UseVisualStyleBackColor = true;
+            // 
+            // groupBoxDetails
+            // 
+            this.groupBoxDetails.Controls.Add(this.pictureBoxPokemon);
+            this.groupBoxDetails.Controls.Add(this.labelSpecies);
+            this.groupBoxDetails.Controls.Add(this.comboBoxSpecies);
+            this.groupBoxDetails.Controls.Add(this.labelMinLevel);
+            this.groupBoxDetails.Controls.Add(this.numericUpDownMinLevel);
+            this.groupBoxDetails.Controls.Add(this.labelMaxLevel);
+            this.groupBoxDetails.Controls.Add(this.numericUpDownMaxLevel);
+            this.groupBoxDetails.Controls.Add(this.labelRate);
+            this.groupBoxDetails.Controls.Add(this.numericUpDownRate);
+            this.groupBoxDetails.Controls.Add(this.labelScore);
+            this.groupBoxDetails.Controls.Add(this.numericUpDownScore);
+            this.groupBoxDetails.Controls.Add(this.labelDummy);
+            this.groupBoxDetails.Controls.Add(this.numericUpDownDummy);
+            this.groupBoxDetails.Controls.Add(this.labelDummyInfo);
+            this.groupBoxDetails.Location = new System.Drawing.Point(312, 6);
+            this.groupBoxDetails.Name = "groupBoxDetails";
+            this.groupBoxDetails.Size = new System.Drawing.Size(280, 270);
+            this.groupBoxDetails.TabIndex = 2;
+            this.groupBoxDetails.TabStop = false;
+            this.groupBoxDetails.Text = "Encounter Details";
+            // 
+            // pictureBoxPokemon
+            // 
+            this.pictureBoxPokemon.BackColor = System.Drawing.Color.White;
+            this.pictureBoxPokemon.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.pictureBoxPokemon.Location = new System.Drawing.Point(200, 19);
+            this.pictureBoxPokemon.Name = "pictureBoxPokemon";
+            this.pictureBoxPokemon.Size = new System.Drawing.Size(68, 56);
+            this.pictureBoxPokemon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            this.pictureBoxPokemon.TabIndex = 14;
+            this.pictureBoxPokemon.TabStop = false;
+            // 
+            // labelSpecies
+            // 
+            this.labelSpecies.AutoSize = true;
+            this.labelSpecies.Location = new System.Drawing.Point(6, 22);
+            this.labelSpecies.Name = "labelSpecies";
+            this.labelSpecies.Size = new System.Drawing.Size(48, 13);
+            this.labelSpecies.TabIndex = 0;
+            this.labelSpecies.Text = "Species:";
+            // 
+            // comboBoxSpecies
+            // 
+            this.comboBoxSpecies.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxSpecies.FormattingEnabled = true;
+            this.comboBoxSpecies.Location = new System.Drawing.Point(75, 19);
+            this.comboBoxSpecies.Name = "comboBoxSpecies";
+            this.comboBoxSpecies.Size = new System.Drawing.Size(119, 21);
+            this.comboBoxSpecies.TabIndex = 1;
+            this.comboBoxSpecies.SelectedIndexChanged += new System.EventHandler(this.comboBoxSpecies_SelectedIndexChanged);
+            // 
+            // labelMinLevel
+            // 
+            this.labelMinLevel.AutoSize = true;
+            this.labelMinLevel.Location = new System.Drawing.Point(6, 50);
+            this.labelMinLevel.Name = "labelMinLevel";
+            this.labelMinLevel.Size = new System.Drawing.Size(56, 13);
+            this.labelMinLevel.TabIndex = 2;
+            this.labelMinLevel.Text = "Min Level:";
+            // 
+            // numericUpDownMinLevel
+            // 
+            this.numericUpDownMinLevel.Location = new System.Drawing.Point(75, 48);
+            this.numericUpDownMinLevel.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMinLevel.Name = "numericUpDownMinLevel";
+            this.numericUpDownMinLevel.Size = new System.Drawing.Size(60, 20);
+            this.numericUpDownMinLevel.TabIndex = 3;
+            this.numericUpDownMinLevel.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMinLevel.ValueChanged += new System.EventHandler(this.numericUpDownMinLevel_ValueChanged);
+            // 
+            // labelMaxLevel
+            // 
+            this.labelMaxLevel.AutoSize = true;
+            this.labelMaxLevel.Location = new System.Drawing.Point(6, 78);
+            this.labelMaxLevel.Name = "labelMaxLevel";
+            this.labelMaxLevel.Size = new System.Drawing.Size(59, 13);
+            this.labelMaxLevel.TabIndex = 4;
+            this.labelMaxLevel.Text = "Max Level:";
+            // 
+            // numericUpDownMaxLevel
+            // 
+            this.numericUpDownMaxLevel.Location = new System.Drawing.Point(75, 76);
+            this.numericUpDownMaxLevel.Minimum = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMaxLevel.Name = "numericUpDownMaxLevel";
+            this.numericUpDownMaxLevel.Size = new System.Drawing.Size(60, 20);
+            this.numericUpDownMaxLevel.TabIndex = 5;
+            this.numericUpDownMaxLevel.Value = new decimal(new int[] {
+            1,
+            0,
+            0,
+            0});
+            this.numericUpDownMaxLevel.ValueChanged += new System.EventHandler(this.numericUpDownMaxLevel_ValueChanged);
+            // 
+            // labelRate
+            // 
+            this.labelRate.AutoSize = true;
+            this.labelRate.Location = new System.Drawing.Point(6, 106);
+            this.labelRate.Name = "labelRate";
+            this.labelRate.Size = new System.Drawing.Size(33, 13);
+            this.labelRate.TabIndex = 6;
+            this.labelRate.Text = "Rate:";
+            // 
+            // numericUpDownRate
+            // 
+            this.numericUpDownRate.Location = new System.Drawing.Point(75, 104);
+            this.numericUpDownRate.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+            this.numericUpDownRate.Name = "numericUpDownRate";
+            this.numericUpDownRate.Size = new System.Drawing.Size(60, 20);
+            this.numericUpDownRate.TabIndex = 7;
+            this.numericUpDownRate.ValueChanged += new System.EventHandler(this.numericUpDownRate_ValueChanged);
+            // 
+            // labelScore
+            // 
+            this.labelScore.AutoSize = true;
+            this.labelScore.Location = new System.Drawing.Point(6, 134);
+            this.labelScore.Name = "labelScore";
+            this.labelScore.Size = new System.Drawing.Size(38, 13);
+            this.labelScore.TabIndex = 8;
+            this.labelScore.Text = "Score:";
+            // 
+            // numericUpDownScore
+            // 
+            this.numericUpDownScore.Location = new System.Drawing.Point(75, 132);
+            this.numericUpDownScore.Maximum = new decimal(new int[] {
+            255,
+            0,
+            0,
+            0});
+            this.numericUpDownScore.Name = "numericUpDownScore";
+            this.numericUpDownScore.Size = new System.Drawing.Size(60, 20);
+            this.numericUpDownScore.TabIndex = 9;
+            this.numericUpDownScore.ValueChanged += new System.EventHandler(this.numericUpDownScore_ValueChanged);
+            // 
+            // labelDummy
+            // 
+            this.labelDummy.AutoSize = true;
+            this.labelDummy.Location = new System.Drawing.Point(6, 168);
+            this.labelDummy.Name = "labelDummy";
+            this.labelDummy.Size = new System.Drawing.Size(64, 13);
+            this.labelDummy.TabIndex = 10;
+            this.labelDummy.Text = "Terminator*:";
+            // 
+            // numericUpDownDummy
+            // 
+            this.numericUpDownDummy.Enabled = false;
+            this.numericUpDownDummy.Hexadecimal = true;
+            this.numericUpDownDummy.Location = new System.Drawing.Point(75, 166);
+            this.numericUpDownDummy.Maximum = new decimal(new int[] {
+            65535,
+            0,
+            0,
+            0});
+            this.numericUpDownDummy.Name = "numericUpDownDummy";
+            this.numericUpDownDummy.Size = new System.Drawing.Size(80, 20);
+            this.numericUpDownDummy.TabIndex = 11;
+            // 
+            // labelDummyInfo
+            // 
+            this.labelDummyInfo.ForeColor = System.Drawing.SystemColors.GrayText;
+            this.labelDummyInfo.Location = new System.Drawing.Point(6, 195);
+            this.labelDummyInfo.Name = "labelDummyInfo";
+            this.labelDummyInfo.Size = new System.Drawing.Size(268, 70);
+            this.labelDummyInfo.TabIndex = 13;
+            this.labelDummyInfo.Text = "* We believe this to be simply the \'end of encounter data\' terminator. Its exact " +
+    "purpose is not fully researched, but it may be relevant in future discoveries.";
+            // 
+            // buttonSave
+            // 
+            this.buttonSave.Image = global::DSPRE.Properties.Resources.saveButton;
+            this.buttonSave.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonSave.Location = new System.Drawing.Point(598, 19);
+            this.buttonSave.Name = "buttonSave";
+            this.buttonSave.Size = new System.Drawing.Size(90, 32);
+            this.buttonSave.TabIndex = 3;
+            this.buttonSave.Text = "Save";
+            this.buttonSave.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonSave.UseVisualStyleBackColor = true;
+            this.buttonSave.Click += new System.EventHandler(this.buttonSave_Click);
+            // 
+            // buttonExport
+            // 
+            this.buttonExport.Image = global::DSPRE.Properties.Resources.exportArrow;
+            this.buttonExport.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonExport.Location = new System.Drawing.Point(598, 57);
+            this.buttonExport.Name = "buttonExport";
+            this.buttonExport.Size = new System.Drawing.Size(90, 32);
+            this.buttonExport.TabIndex = 4;
+            this.buttonExport.Text = "Export";
+            this.buttonExport.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonExport.UseVisualStyleBackColor = true;
+            this.buttonExport.Click += new System.EventHandler(this.buttonExport_Click);
+            // 
+            // buttonImport
+            // 
+            this.buttonImport.Image = global::DSPRE.Properties.Resources.importArrow;
+            this.buttonImport.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonImport.Location = new System.Drawing.Point(598, 95);
+            this.buttonImport.Name = "buttonImport";
+            this.buttonImport.Size = new System.Drawing.Size(90, 32);
+            this.buttonImport.TabIndex = 5;
+            this.buttonImport.Text = "Import";
+            this.buttonImport.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonImport.UseVisualStyleBackColor = true;
+            this.buttonImport.Click += new System.EventHandler(this.buttonImport_Click);
+            // 
+            // buttonLocate
+            // 
+            this.buttonLocate.Image = global::DSPRE.Properties.Resources.lens;
+            this.buttonLocate.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.buttonLocate.Location = new System.Drawing.Point(598, 133);
+            this.buttonLocate.Name = "buttonLocate";
+            this.buttonLocate.Size = new System.Drawing.Size(90, 32);
+            this.buttonLocate.TabIndex = 6;
+            this.buttonLocate.Text = "Locate";
+            this.buttonLocate.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.buttonLocate.UseVisualStyleBackColor = true;
+            this.buttonLocate.Click += new System.EventHandler(this.buttonLocate_Click);
+            // 
+            // BugContestEncounterEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.labelNotAvailable);
+            this.Controls.Add(this.panelMain);
+            this.Name = "BugContestEncounterEditor";
+            this.Size = new System.Drawing.Size(850, 564);
+            this.panelMain.ResumeLayout(false);
+            this.groupBoxInfo.ResumeLayout(false);
+            this.groupBoxSet.ResumeLayout(false);
+            this.groupBoxEncounters.ResumeLayout(false);
+            this.groupBoxDetails.ResumeLayout(false);
+            this.groupBoxDetails.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxPokemon)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMinLevel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownMaxLevel)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownRate)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownScore)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.numericUpDownDummy)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelNotAvailable;
+        private System.Windows.Forms.Panel panelMain;
+        private System.Windows.Forms.GroupBox groupBoxSet;
+        private System.Windows.Forms.ComboBox comboBoxSet;
+        private System.Windows.Forms.Label labelSetDescription;
+        private System.Windows.Forms.GroupBox groupBoxEncounters;
+        private System.Windows.Forms.ListBox listBoxEncounters;
+        private System.Windows.Forms.Button buttonAdd;
+        private System.Windows.Forms.Button buttonRemove;
+        private System.Windows.Forms.GroupBox groupBoxDetails;
+        private System.Windows.Forms.PictureBox pictureBoxPokemon;
+        private System.Windows.Forms.Label labelSpecies;
+        private System.Windows.Forms.ComboBox comboBoxSpecies;
+        private System.Windows.Forms.Label labelMinLevel;
+        private System.Windows.Forms.NumericUpDown numericUpDownMinLevel;
+        private System.Windows.Forms.Label labelMaxLevel;
+        private System.Windows.Forms.NumericUpDown numericUpDownMaxLevel;
+        private System.Windows.Forms.Label labelRate;
+        private System.Windows.Forms.NumericUpDown numericUpDownRate;
+        private System.Windows.Forms.Label labelScore;
+        private System.Windows.Forms.NumericUpDown numericUpDownScore;
+        private System.Windows.Forms.Label labelDummy;
+        private System.Windows.Forms.NumericUpDown numericUpDownDummy;
+        private System.Windows.Forms.Label labelDummyInfo;
+        private System.Windows.Forms.Button buttonSave;
+        private System.Windows.Forms.Button buttonExport;
+        private System.Windows.Forms.Button buttonImport;
+        private System.Windows.Forms.Button buttonLocate;
+        private System.Windows.Forms.GroupBox groupBoxInfo;
+        private System.Windows.Forms.Label labelInfo;
+        private System.Windows.Forms.ToolTip toolTip1;
+    }
+}

--- a/DS_Map/Editors/BugContestEncounterEditor.cs
+++ b/DS_Map/Editors/BugContestEncounterEditor.cs
@@ -1,0 +1,328 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+using DSPRE.ROMFiles;
+
+namespace DSPRE.Editors {
+    public partial class BugContestEncounterEditor : UserControl {
+        public bool bugContestEncounterEditorIsReady { get; set; } = false;
+        private BugContestEncounterFile bugContestEncounterFile;
+        private int currentSetIndex = 0;
+
+        public BugContestEncounterEditor() {
+            InitializeComponent();
+            SetupTooltips();
+        }
+
+        private void SetupTooltips() {
+            // Add/Remove buttons are disabled with explanatory tooltips
+            toolTip1.SetToolTip(buttonAdd, 
+                "Add a new encounter to this set.\n\n" +
+                "NOT YET AVAILABLE: Research into how to expand or reduce\n" +
+                "the encounter file is not yet finished. Each set must have\n" +
+                "exactly 10 encounters until a proper patching method exists.");
+
+            toolTip1.SetToolTip(buttonRemove, 
+                "Remove the selected encounter from this set.\n\n" +
+                "NOT YET AVAILABLE: Research into how to expand or reduce\n" +
+                "the encounter file is not yet finished. Each set must have\n" +
+                "exactly 10 encounters until a proper patching method exists.");
+
+            toolTip1.SetToolTip(buttonSave, "Save changes to the ROM.");
+            toolTip1.SetToolTip(buttonExport, "Export encounters to an external file.");
+            toolTip1.SetToolTip(buttonImport, "Import encounters from an external file.");
+            toolTip1.SetToolTip(buttonLocate, "Open the folder containing the encounter file.");
+
+            toolTip1.SetToolTip(numericUpDownDummy, 
+                "This field is read-only. We believe this to be simply the\n" +
+                "'end of encounter data' terminator or padding.");
+        }
+
+        public void SetupBugContestEncounterEditor(bool force = false) {
+            if (bugContestEncounterEditorIsReady && !force) { return; }
+            bugContestEncounterEditorIsReady = true;
+
+            if (!BugContestEncounterFile.IsAvailable()) {
+                labelNotAvailable.Visible = true;
+                panelMain.Visible = false;
+                return;
+            }
+
+            labelNotAvailable.Visible = false;
+            panelMain.Visible = true;
+
+            if (!Filesystem.BugContestEncounterFileExists()) {
+                MessageBox.Show(
+                    "Bug Contest encounter file not found.\nExpected location: data/mushi/mushi_encount.bin",
+                    "File Not Found",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+                return;
+            }
+
+            DSUtils.TryUnpackNarcs(new List<RomInfo.DirNames> { RomInfo.DirNames.monIcons });
+            RomInfo.SetMonIconsPalTableAddress();
+
+            string[] pokemonNames = RomInfo.GetPokemonNames();
+            comboBoxSpecies.Items.Clear();
+            comboBoxSpecies.Items.AddRange(pokemonNames);
+
+            LoadEncounterFile();
+        }
+
+        private void LoadEncounterFile() {
+            try {
+                bugContestEncounterFile = new BugContestEncounterFile(true);
+                
+                Helpers.DisableHandlers();
+                try {
+                    comboBoxSet.Items.Clear();
+                    foreach (var set in bugContestEncounterFile.Sets) {
+                        comboBoxSet.Items.Add(set);
+                    }
+                    
+                    if (comboBoxSet.Items.Count > 0) {
+                        comboBoxSet.SelectedIndex = 0;
+                    }
+                } finally {
+                    Helpers.EnableHandlers();
+                }
+                
+                currentSetIndex = 0;
+                RefreshSetDisplay();
+                
+            } catch (Exception ex) {
+                MessageBox.Show(
+                    $"Error loading Bug Contest encounters: {ex.Message}",
+                    "Error",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Error);
+            }
+        }
+
+        private void RefreshSetDisplay() {
+            if (bugContestEncounterFile == null || currentSetIndex < 0 || currentSetIndex >= bugContestEncounterFile.Sets.Count) {
+                return;
+            }
+
+            var currentSet = bugContestEncounterFile.Sets[currentSetIndex];
+            
+            labelSetDescription.Text = currentSet.Description;
+            
+            listBoxEncounters.DataSource = null;
+            listBoxEncounters.DataSource = currentSet.Encounters;
+            
+            if (listBoxEncounters.Items.Count > 0) {
+                listBoxEncounters.SelectedIndex = 0;
+            }
+        }
+
+        private void comboBoxSet_SelectedIndexChanged(object sender, EventArgs e) {
+            if (Helpers.HandlersDisabled) return;
+            
+            currentSetIndex = comboBoxSet.SelectedIndex;
+            RefreshSetDisplay();
+        }
+
+        private void listBoxEncounters_SelectedIndexChanged(object sender, EventArgs e) {
+            if (Helpers.HandlersDisabled) return;
+            
+            if (listBoxEncounters.SelectedIndex < 0 || bugContestEncounterFile == null) {
+                ClearFields();
+                return;
+            }
+
+            var currentSet = bugContestEncounterFile.Sets[currentSetIndex];
+            if (listBoxEncounters.SelectedIndex >= currentSet.Encounters.Count) {
+                ClearFields();
+                return;
+            }
+
+            var encounter = currentSet.Encounters[listBoxEncounters.SelectedIndex];
+            
+            Helpers.DisableHandlers();
+            try {
+                comboBoxSpecies.SelectedIndex = encounter.Species < comboBoxSpecies.Items.Count ? encounter.Species : 0;
+                numericUpDownMinLevel.Value = Math.Max(numericUpDownMinLevel.Minimum, Math.Min(numericUpDownMinLevel.Maximum, encounter.MinLevel));
+                numericUpDownMaxLevel.Value = Math.Max(numericUpDownMaxLevel.Minimum, Math.Min(numericUpDownMaxLevel.Maximum, encounter.MaxLevel));
+                numericUpDownRate.Value = encounter.Rate;
+                numericUpDownScore.Value = encounter.Score;
+                numericUpDownDummy.Value = encounter.Dummy;
+                
+                UpdatePokemonIcon(encounter.Species);
+            } finally {
+                Helpers.EnableHandlers();
+            }
+        }
+
+        private void UpdatePokemonIcon(int species) {
+            try {
+                if (species <= 0) {
+                    pictureBoxPokemon.Image = Properties.Resources.IconPokeball;
+                    return;
+                }
+
+                Image icon = DSUtils.GetPokePic(species, pictureBoxPokemon.Width, pictureBoxPokemon.Height);
+                if (icon != null) {
+                    pictureBoxPokemon.Image = icon;
+                } else {
+                    pictureBoxPokemon.Image = Properties.Resources.IconPokeball;
+                }
+            } catch {
+                pictureBoxPokemon.Image = Properties.Resources.IconPokeball;
+            }
+        }
+
+        private void ClearFields() {
+            Helpers.DisableHandlers();
+            try {
+                comboBoxSpecies.SelectedIndex = -1;
+                numericUpDownMinLevel.Value = 1;
+                numericUpDownMaxLevel.Value = 1;
+                numericUpDownRate.Value = 0;
+                numericUpDownScore.Value = 0;
+                numericUpDownDummy.Value = 0;
+                pictureBoxPokemon.Image = null;
+            } finally {
+                Helpers.EnableHandlers();
+            }
+        }
+
+        private void UpdateSelectedEncounter() {
+            if (Helpers.HandlersDisabled) return;
+            if (bugContestEncounterFile == null) return;
+            if (currentSetIndex < 0 || currentSetIndex >= bugContestEncounterFile.Sets.Count) return;
+            if (listBoxEncounters.SelectedIndex < 0) return;
+
+            var currentSet = bugContestEncounterFile.Sets[currentSetIndex];
+            if (listBoxEncounters.SelectedIndex >= currentSet.Encounters.Count) return;
+
+            var encounter = currentSet.Encounters[listBoxEncounters.SelectedIndex];
+
+            encounter.Species = (ushort)(comboBoxSpecies.SelectedIndex >= 0 ? comboBoxSpecies.SelectedIndex : 0);
+            encounter.MinLevel = (byte)numericUpDownMinLevel.Value;
+            encounter.MaxLevel = (byte)numericUpDownMaxLevel.Value;
+            encounter.Rate = (byte)numericUpDownRate.Value;
+            encounter.Score = (byte)numericUpDownScore.Value;
+            // Dummy/Terminator is read-only, don't update it
+
+            // Refresh the display
+            int selectedIndex = listBoxEncounters.SelectedIndex;
+            listBoxEncounters.DataSource = null;
+            listBoxEncounters.DataSource = currentSet.Encounters;
+            listBoxEncounters.SelectedIndex = selectedIndex;
+        }
+
+        private void comboBoxSpecies_SelectedIndexChanged(object sender, EventArgs e) {
+            if (Helpers.HandlersDisabled) return;
+            
+            UpdateSelectedEncounter();
+            
+            // Update icon when species changes
+            if (comboBoxSpecies.SelectedIndex >= 0) {
+                UpdatePokemonIcon(comboBoxSpecies.SelectedIndex);
+            }
+        }
+
+        private void numericUpDownMinLevel_ValueChanged(object sender, EventArgs e) {
+            UpdateSelectedEncounter();
+        }
+
+        private void numericUpDownMaxLevel_ValueChanged(object sender, EventArgs e) {
+            UpdateSelectedEncounter();
+        }
+
+        private void numericUpDownRate_ValueChanged(object sender, EventArgs e) {
+            UpdateSelectedEncounter();
+        }
+
+        private void numericUpDownScore_ValueChanged(object sender, EventArgs e) {
+            UpdateSelectedEncounter();
+        }
+
+        private void buttonSave_Click(object sender, EventArgs e) {
+            if (bugContestEncounterFile == null) return;
+            bugContestEncounterFile.SaveToFile();
+        }
+
+        private void buttonExport_Click(object sender, EventArgs e) {
+            if (bugContestEncounterFile == null) return;
+
+            SaveFileDialog sfd = new SaveFileDialog {
+                Filter = "Binary files (*.bin)|*.bin|All files (*.*)|*.*",
+                DefaultExt = "bin",
+                FileName = "mushi_encount.bin"
+            };
+
+            try {
+                sfd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            } catch { }
+
+            if (sfd.ShowDialog() == DialogResult.OK) {
+                bugContestEncounterFile.SaveToFile(sfd.FileName);
+            }
+        }
+
+        private void buttonImport_Click(object sender, EventArgs e) {
+            OpenFileDialog ofd = new OpenFileDialog {
+                Filter = "Binary files (*.bin)|*.bin|All files (*.*)|*.*",
+                DefaultExt = "bin"
+            };
+
+            try {
+                ofd.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            } catch { }
+
+            if (ofd.ShowDialog() == DialogResult.OK) {
+                try {
+                    bugContestEncounterFile = new BugContestEncounterFile(ofd.FileName);
+                    
+                    // Re-populate set selector
+                    Helpers.DisableHandlers();
+                    try {
+                        comboBoxSet.Items.Clear();
+                        foreach (var set in bugContestEncounterFile.Sets) {
+                            comboBoxSet.Items.Add(set);
+                        }
+                        
+                        if (comboBoxSet.Items.Count > 0) {
+                            comboBoxSet.SelectedIndex = 0;
+                        }
+                    } finally {
+                        Helpers.EnableHandlers();
+                    }
+                    
+                    currentSetIndex = 0;
+                    RefreshSetDisplay();
+                    
+                    MessageBox.Show(
+                        "Bug Contest encounters imported successfully!",
+                        "Import Complete",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Information);
+                } catch (Exception ex) {
+                    MessageBox.Show(
+                        $"Error importing file: {ex.Message}",
+                        "Import Error",
+                        MessageBoxButtons.OK,
+                        MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void buttonLocate_Click(object sender, EventArgs e) {
+            string path = Filesystem.GetBugContestEncounterPath();
+            if (File.Exists(path)) {
+                Helpers.ExplorerSelect(path);
+            } else {
+                MessageBox.Show(
+                    "Bug Contest encounter file not found.",
+                    "File Not Found",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning);
+            }
+        }
+    }
+}

--- a/DS_Map/Editors/BugContestEncounterEditor.resx
+++ b/DS_Map/Editors/BugContestEncounterEditor.resx
@@ -1,0 +1,140 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="labelInfo.Text" xml:space="preserve">
+    <value>Bug Catching Contest encounters for HeartGold/SoulSilver.
+
+The game uses 4 sets of 10 encounters each:
+- Set 0: Without National Dex (always), or with National Dex on Sun/Mon
+- Set 1: With National Dex on Tuesday/Wednesday
+- Set 2: With National Dex on Thursday/Friday
+- Set 3: With National Dex on Saturday
+
+Fields:
+- Species: The Pokemon that can appear
+- Min/Max Level: Level range when encountered
+- Rate: Encounter rate weight (higher = more common)
+- Score: Base score value for judging
+
+File: data/mushi/mushi_encount.bin</value>
+  </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/DS_Map/Editors/EncountersEditor.Designer.cs
+++ b/DS_Map/Editors/EncountersEditor.Designer.cs
@@ -34,15 +34,19 @@ namespace DSPRE.Editors
             this.headbuttEncounterEditor = new DSPRE.Editors.HeadbuttEncounterEditor();
             this.tabPageSafariZoneEditor = new System.Windows.Forms.TabPage();
             this.safariZoneEditor = new DSPRE.Editors.SafariZoneEditor();
+            this.tabPageBugContestEditor = new System.Windows.Forms.TabPage();
+            this.bugContestEncounterEditor = new DSPRE.Editors.BugContestEncounterEditor();
             this.tabControl.SuspendLayout();
             this.tabPageHeadbuttEditor.SuspendLayout();
             this.tabPageSafariZoneEditor.SuspendLayout();
+            this.tabPageBugContestEditor.SuspendLayout();
             this.SuspendLayout();
             // 
             // tabControl
             // 
             this.tabControl.Controls.Add(this.tabPageHeadbuttEditor);
             this.tabControl.Controls.Add(this.tabPageSafariZoneEditor);
+            this.tabControl.Controls.Add(this.tabPageBugContestEditor);
             this.tabControl.Location = new System.Drawing.Point(4, 4);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
@@ -90,6 +94,26 @@ namespace DSPRE.Editors
             this.safariZoneEditor.Size = new System.Drawing.Size(996, 341);
             this.safariZoneEditor.TabIndex = 1;
             // 
+            // tabPageBugContestEditor
+            // 
+            this.tabPageBugContestEditor.Controls.Add(this.bugContestEncounterEditor);
+            this.tabPageBugContestEditor.Location = new System.Drawing.Point(4, 22);
+            this.tabPageBugContestEditor.Name = "tabPageBugContestEditor";
+            this.tabPageBugContestEditor.Padding = new System.Windows.Forms.Padding(3);
+            this.tabPageBugContestEditor.Size = new System.Drawing.Size(1095, 628);
+            this.tabPageBugContestEditor.TabIndex = 2;
+            this.tabPageBugContestEditor.Text = "Bug Contest";
+            this.tabPageBugContestEditor.UseVisualStyleBackColor = true;
+            this.tabPageBugContestEditor.Enter += new System.EventHandler(this.tabPageBugContestEditor_Enter);
+            // 
+            // bugContestEncounterEditor
+            // 
+            this.bugContestEncounterEditor.bugContestEncounterEditorIsReady = false;
+            this.bugContestEncounterEditor.Location = new System.Drawing.Point(6, 6);
+            this.bugContestEncounterEditor.Name = "bugContestEncounterEditor";
+            this.bugContestEncounterEditor.Size = new System.Drawing.Size(700, 400);
+            this.bugContestEncounterEditor.TabIndex = 0;
+            // 
             // EncountersEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -100,6 +124,7 @@ namespace DSPRE.Editors
             this.tabControl.ResumeLayout(false);
             this.tabPageHeadbuttEditor.ResumeLayout(false);
             this.tabPageSafariZoneEditor.ResumeLayout(false);
+            this.tabPageBugContestEditor.ResumeLayout(false);
             this.ResumeLayout(false);
 
     }
@@ -111,5 +136,7 @@ namespace DSPRE.Editors
     private System.Windows.Forms.TabPage tabPageHeadbuttEditor;
     private System.Windows.Forms.TabPage tabPageSafariZoneEditor;
     public SafariZoneEditor safariZoneEditor;
+    private System.Windows.Forms.TabPage tabPageBugContestEditor;
+    public BugContestEncounterEditor bugContestEncounterEditor;
   }
 }

--- a/DS_Map/Editors/EncountersEditor.cs
+++ b/DS_Map/Editors/EncountersEditor.cs
@@ -26,5 +26,10 @@ namespace DSPRE.Editors
     {
       safariZoneEditor.SetupSafariZoneEditor();
     }
+
+    private void tabPageBugContestEditor_Enter(object sender, System.EventArgs e)
+    {
+      bugContestEncounterEditor.SetupBugContestEncounterEditor();
+    }
   }
 }

--- a/DS_Map/Filesystem.cs
+++ b/DS_Map/Filesystem.cs
@@ -25,6 +25,22 @@ namespace DSPRE {
         public static string interiorBuildingModels => RomInfo.gameDirs[RomInfo.DirNames.interiorBuildingModels].unpackedDir;
         public static string exteriorBuildingModels => RomInfo.gameDirs[RomInfo.DirNames.exteriorBuildingModels].unpackedDir;
 
+        /// <summary>
+        /// Gets the path to the Bug Contest encounter file (HGSS only).
+        /// This is a single file, not a NARC.
+        /// Path in ROM filesystem: data/mushi/mushi_encount.bin
+        /// </summary>
+        public static string GetBugContestEncounterPath() {
+            return Path.Combine(RomInfo.dataPath, "data", "mushi", "mushi_encount.bin");
+        }
+
+        /// <summary>
+        /// Checks if the Bug Contest encounter file exists.
+        /// </summary>
+        public static bool BugContestEncounterFileExists() {
+            return File.Exists(GetBugContestEncounterPath());
+        }
+
         public static string GetBuildingModelsDirPath(bool interior) {
             if (interior) {
                 return interiorBuildingModels;

--- a/DS_Map/ROMFiles/BugContestEncounterFile.cs
+++ b/DS_Map/ROMFiles/BugContestEncounterFile.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+
+namespace DSPRE.ROMFiles {
+    /// <summary>
+    /// Represents a Bug Contest encounter entry (BUGMON structure).
+    /// File location: data/mushi/mushi_encount.bin (HGSS only)
+    /// Structure: 8 bytes per entry
+    /// </summary>
+    public class BugContestEncounter {
+        public ushort Species { get; set; }
+        public byte MinLevel { get; set; }
+        public byte MaxLevel { get; set; }
+        public byte Rate { get; set; }
+        public byte Score { get; set; }
+        /// <summary>
+        /// Believed to be an end-of-encounter-data terminator or padding.
+        /// Purpose not fully researched yet.
+        /// </summary>
+        public ushort Dummy { get; set; }
+
+        public BugContestEncounter() {
+            Species = 0;
+            MinLevel = 1;
+            MaxLevel = 1;
+            Rate = 0;
+            Score = 0;
+            Dummy = 0;
+        }
+
+        public BugContestEncounter(BinaryReader br) {
+            Species = br.ReadUInt16();
+            MinLevel = br.ReadByte();
+            MaxLevel = br.ReadByte();
+            Rate = br.ReadByte();
+            Score = br.ReadByte();
+            Dummy = br.ReadUInt16();
+        }
+
+        public void Write(BinaryWriter bw) {
+            bw.Write(Species);
+            bw.Write(MinLevel);
+            bw.Write(MaxLevel);
+            bw.Write(Rate);
+            bw.Write(Score);
+            bw.Write(Dummy);
+        }
+
+        public override string ToString() {
+            string[] pokemonNames = RomInfo.GetPokemonNames();
+            string name = Species < pokemonNames.Length ? pokemonNames[Species] : $"Pokemon {Species}";
+            return $"{name} (Lv.{MinLevel}-{MaxLevel}, Rate:{Rate}, Score:{Score})";
+        }
+    }
+
+    /// <summary>
+    /// Represents a set of Bug Contest encounters.
+    /// Each set contains ENCOUNTERS_PER_SET (10) encounters.
+    /// </summary>
+    public class BugContestEncounterSet {
+        public string Name { get; }
+        public string Description { get; }
+        public BindingList<BugContestEncounter> Encounters { get; }
+
+        public BugContestEncounterSet(string name, string description) {
+            Name = name;
+            Description = description;
+            Encounters = new BindingList<BugContestEncounter>();
+        }
+
+        public override string ToString() => Name;
+    }
+
+    /// <summary>
+    /// Represents the Bug Contest encounter file for HeartGold/SoulSilver.
+    /// Contains 4 sets of 10 encounters each (40 total).
+    /// File: data/mushi/mushi_encount.bin
+    /// 
+    /// Set selection logic from game code:
+    /// - Without National Dex: Always Set 0
+    /// - With National Dex: set = day_of_week / 2
+    ///   - Sunday(0)/Monday(1) -> Set 0
+    ///   - Tuesday(2)/Wednesday(3) -> Set 1  
+    ///   - Thursday(4)/Friday(5) -> Set 2
+    ///   - Saturday(6) -> Set 3
+    /// </summary>
+    public class BugContestEncounterFile : RomFile {
+        public const int ENTRY_SIZE = 8;
+        public const int ENCOUNTERS_PER_SET = 10;
+        public const int SET_COUNT = 4;
+        public const int TOTAL_ENTRIES = SET_COUNT * ENCOUNTERS_PER_SET; // 40
+
+        public List<BugContestEncounterSet> Sets { get; private set; }
+
+        /// <summary>
+        /// Gets all encounters as a flat list for backward compatibility.
+        /// </summary>
+        public BindingList<BugContestEncounter> Encounters {
+            get {
+                var all = new BindingList<BugContestEncounter>();
+                foreach (var set in Sets) {
+                    foreach (var enc in set.Encounters) {
+                        all.Add(enc);
+                    }
+                }
+                return all;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new empty Bug Contest encounter file with proper structure.
+        /// </summary>
+        public BugContestEncounterFile() {
+            Sets = new List<BugContestEncounterSet> {
+                new BugContestEncounterSet("Set 0: No National Dex / Sun-Mon", 
+                    "Used when player doesn't have National Dex,\nor with National Dex on Sunday/Monday."),
+                new BugContestEncounterSet("Set 1: Nat Dex - Tue/Wed", 
+                    "Used with National Dex on Tuesday/Wednesday."),
+                new BugContestEncounterSet("Set 2: Nat Dex - Thu/Fri", 
+                    "Used with National Dex on Thursday/Friday."),
+                new BugContestEncounterSet("Set 3: Nat Dex - Saturday", 
+                    "Used with National Dex on Saturday only.")
+            };
+        }
+
+        /// <summary>
+        /// Loads the Bug Contest encounter file from the default path.
+        /// </summary>
+        public BugContestEncounterFile(bool load) : this() {
+            if (load) {
+                string path = Filesystem.GetBugContestEncounterPath();
+                if (File.Exists(path)) {
+                    ParseFile(path);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Loads the Bug Contest encounter file from a specific path.
+        /// </summary>
+        public BugContestEncounterFile(string path) : this() {
+            ParseFile(path);
+        }
+
+        private void ParseFile(string path) {
+            using (FileStream fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+            using (BinaryReader br = new BinaryReader(fs)) {
+                // Clear existing encounters in each set
+                foreach (var set in Sets) {
+                    set.Encounters.Clear();
+                }
+
+                int totalEntries = (int)(fs.Length / ENTRY_SIZE);
+                int entryIndex = 0;
+
+                // Read entries and distribute to sets
+                while (fs.Position + ENTRY_SIZE <= fs.Length && entryIndex < TOTAL_ENTRIES) {
+                    int setIndex = entryIndex / ENCOUNTERS_PER_SET;
+                    if (setIndex < Sets.Count) {
+                        Sets[setIndex].Encounters.Add(new BugContestEncounter(br));
+                    }
+                    entryIndex++;
+                }
+
+                // Ensure each set has exactly 10 entries (fill with empty if needed)
+                foreach (var set in Sets) {
+                    while (set.Encounters.Count < ENCOUNTERS_PER_SET) {
+                        set.Encounters.Add(new BugContestEncounter());
+                    }
+                }
+            }
+        }
+
+        public override byte[] ToByteArray() {
+            using (MemoryStream ms = new MemoryStream())
+            using (BinaryWriter bw = new BinaryWriter(ms)) {
+                // Write all sets in order
+                foreach (var set in Sets) {
+                    foreach (var encounter in set.Encounters) {
+                        encounter.Write(bw);
+                    }
+                }
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Saves the Bug Contest encounter file to the default path.
+        /// </summary>
+        public bool SaveToFile(bool showSuccessMessage = true) {
+            string path = Filesystem.GetBugContestEncounterPath();
+            return SaveToFile(path, showSuccessMessage);
+        }
+
+        /// <summary>
+        /// Saves the Bug Contest encounter file to a specific path.
+        /// </summary>
+        public new bool SaveToFile(string path, bool showSuccessMessage = true) {
+            try {
+                byte[] data = ToByteArray();
+                File.WriteAllBytes(path, data);
+
+                if (showSuccessMessage) {
+                    System.Windows.Forms.MessageBox.Show(
+                        "Bug Contest encounters saved successfully!",
+                        "Success",
+                        System.Windows.Forms.MessageBoxButtons.OK,
+                        System.Windows.Forms.MessageBoxIcon.Information);
+                }
+                return true;
+            } catch (Exception ex) {
+                System.Windows.Forms.MessageBox.Show(
+                    $"Error saving Bug Contest encounters: {ex.Message}",
+                    "Error",
+                    System.Windows.Forms.MessageBoxButtons.OK,
+                    System.Windows.Forms.MessageBoxIcon.Error);
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Checks if Bug Contest encounters are available (HGSS only).
+        /// </summary>
+        public static bool IsAvailable() {
+            return RomInfo.gameFamily == RomInfo.GameFamilies.HGSS;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new feature for editing Bug Catching Contest encounters in HeartGold/SoulSilver. It adds a dedicated editor UI for these encounters, integrates the editor into the main `EncountersEditor` tab interface, and updates the project configuration to include all necessary files and resources.

New Bug Contest Encounter Editor feature:

* Added the `BugContestEncounterEditor` user control, which provides a UI for viewing and editing Bug Catching Contest encounters, including file loading, saving, importing/exporting, and displaying Pokémon icons. (`BugContestEncounterEditor.cs`, [DS_Map/Editors/BugContestEncounterEditor.csR1-R328](diffhunk://#diff-0828f33fc8e49bf88a4edf491044de469a4268f8f70fbd609724e7c1ed96c408R1-R328))
* Added the resource file `BugContestEncounterEditor.resx` for UI text and tooltips, describing the encounter sets and fields. (`BugContestEncounterEditor.resx`, [DS_Map/Editors/BugContestEncounterEditor.resxR1-R140](diffhunk://#diff-d290e0a1a9a591fff1d65d650e1784302d3cc52553753ebd98e04f87765a6545R1-R140))

Integration into the main editor:

* Updated `EncountersEditor.Designer.cs` to add a new "Bug Contest" tab and embed the `BugContestEncounterEditor` within it, including event wiring and layout. [[1]](diffhunk://#diff-0f5064d05d04416fa0b83765ae659a58d1a6e947f1c00bdc9c939ca3d5070437R37-R49) [[2]](diffhunk://#diff-0f5064d05d04416fa0b83765ae659a58d1a6e947f1c00bdc9c939ca3d5070437R97-R116) [[3]](diffhunk://#diff-0f5064d05d04416fa0b83765ae659a58d1a6e947f1c00bdc9c939ca3d5070437R127)

Project configuration updates:

* Modified `DSPRE.csproj` to include the new editor code files, designer file, embedded resource, and the related `BugContestEncounterFile` logic file. [[1]](diffhunk://#diff-ad3bea2f9e23b6bf9c0b0eb9404475ea1462cc5d2d79a2cf9bea376775ed40e4R116-R121) [[2]](diffhunk://#diff-ad3bea2f9e23b6bf9c0b0eb9404475ea1462cc5d2d79a2cf9bea376775ed40e4R418) [[3]](diffhunk://#diff-ad3bea2f9e23b6bf9c0b0eb9404475ea1462cc5d2d79a2cf9bea376775ed40e4R567-R569)