### PR TITLE
Make Map Editor texture preview more game-faithful

### DIFF
--- a/.github/workflows/MrHamm-canary-build.yaml
+++ b/.github/workflows/MrHamm-canary-build.yaml
@@ -1,0 +1,102 @@
+name: MrHam's DSPRE Canary Build
+
+on:
+  push:
+    branches:
+      - main  # Trigger only on pushes to the main branch
+
+permissions:
+  contents: write
+  actions: write
+
+env:
+  SOLUTION_FILE_PATH: DS_Map.sln
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    if: github.repository == 'DevHam88/DSPRE'
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+      
+    - name: Clone Database Repository
+      run: |
+        git clone https://github.com/DS-Pokemon-Rom-Editor/scrcmd-database.git databases
+
+    - name: Clone ds-rom Repository
+      run: |
+        git clone --depth 1 https://github.com/DS-Pokemon-Rom-Editor/ds-rom.git ds-rom
+        
+    - name: Restore NuGet packages
+      working-directory: ${{ github.workspace }}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build DSPRE
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+    
+    - name: Build dsrom.exe
+      run: |
+        cargo build --release -p ds-rom-cli --manifest-path ds-rom/Cargo.toml
+        New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\DS_Map\bin\Release\Tools" | Out-Null
+        Copy-Item -Path "${{ github.workspace }}\ds-rom\target\release\dsrom.exe" -Destination "${{ github.workspace }}\DS_Map\bin\Release\Tools\dsrom.exe" -Force
+    
+    - name: Prepare Release Files
+      run: |
+        mkdir "${{ github.workspace }}\DS_Map\bin\Release\databases"
+        robocopy databases "${{ github.workspace }}\DS_Map\bin\Release\databases" /E /XD "databases\.git\objects\pack"
+        if ($LASTEXITCODE -le 7) { exit 0 } else { exit 1 }
+
+    - name: Zip Release Files
+      run: Compress-Archive -Path "${{ github.workspace }}\DS_Map\bin\Release\*" -DestinationPath DSPRE-MrHam-canary-${{ github.sha }}.zip
+
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+
+    - name: Delete previous release
+      run: |
+        gh release delete --yes canary || true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update canary tag
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -f canary -m "Canary build for commit ${{ github.sha }}"
+        git push -f origin canary
+    
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        
+    - name: Create new release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: canary
+        name: MrHam's DSPRE Canary Build ${{ steps.date.outputs.date }} (${{ github.sha }})
+        files: DSPRE-MrHam-canary-${{ github.sha }}.zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        body: |
+          ##  ⚠️ Canary Build Notice ⚠️
+          This is a Canary Build of DSPRE, meaning it is automatically generated from the latest pushed code. It includes the most recent changes, improvements, and experimental features, but may be unstable or contain bugs.
+          
+          ## 🚧 What does this mean?
+          This build reflects ongoing development and is not a stable release.
+          Features may be incomplete, subject to change, or cause unexpected issues.
+          Use at your own risk—expect potential crashes, broken functionality, or unpolished features.
+          
+          ## 💡 Who is this for?
+          Developers and testers who want to stay up-to-date with the latest progress.
+          Users willing to report issues and provide feedback on new changes.
+          If you’re looking for a more reliable version, consider using the latest Stable Release instead.
+        prerelease: true
+        generate_release_notes: true

--- a/DS_Map/Editors/MapEditor.Designer.cs
+++ b/DS_Map/Editors/MapEditor.Designer.cs
@@ -403,9 +403,9 @@
             this.label26.AutoSize = true;
             this.label26.Location = new System.Drawing.Point(16, 574);
             this.label26.Name = "label26";
-            this.label26.Size = new System.Drawing.Size(84, 13);
+            this.label26.Size = new System.Drawing.Size(151, 13);
             this.label26.TabIndex = 33;
-            this.label26.Text = "Buildings texture";
+            this.label26.Text = "Buildings texture (preview only)";
             // 
             // buildTextureComboBox
             // 
@@ -441,9 +441,9 @@
             this.mapTextureLabel.AutoSize = true;
             this.mapTextureLabel.Location = new System.Drawing.Point(16, 530);
             this.mapTextureLabel.Name = "mapTextureLabel";
-            this.mapTextureLabel.Size = new System.Drawing.Size(63, 13);
+            this.mapTextureLabel.Size = new System.Drawing.Size(130, 13);
             this.mapTextureLabel.TabIndex = 29;
-            this.mapTextureLabel.Text = "Map texture";
+            this.mapTextureLabel.Text = "Map texture (preview only)";
             // 
             // selectMapComboBox
             // 

--- a/DS_Map/LibNDSFormats/NSBMD/NSBMD.cs
+++ b/DS_Map/LibNDSFormats/NSBMD/NSBMD.cs
@@ -50,9 +50,17 @@ namespace LibNDSFormats.NSBMD {
         public void MatchTextures() {
             foreach (NSBMDModel m in models) {
                 for (int j = 0; j < m.Polygons.Count - 1; j++) {
+                    int matId = m.Polygons[j].MatId;
+                    if (matId < 0 || matId >= m.Materials.Count) {
+                        continue;
+                    }
+
+                    NSBMDMaterial mat = m.Materials[matId];
+                    mat.missingExternalTexture = false;
+
                     for (int t = 0; t < m.Textures.Count; t++) {
-                        if (m.Textures[t].texmatid.Contains((uint)m.Polygons[j].MatId)) {
-                            int texid = t;
+                        if (m.Textures[t].texmatid.Contains((uint)matId)) {
+                            int texid = -1;
                             for (int l = 0; l < Textures.Count; l++) {
                                 if (Textures[l].texname == m.Textures[t].texname) {
                                     texid = l;
@@ -60,7 +68,11 @@ namespace LibNDSFormats.NSBMD {
                                 }
                             }
 
-                            NSBMDMaterial mat = m.Materials[m.Polygons[j].MatId];
+                            if (texid < 0) {
+                                MarkMissingExternalTexture(mat);
+                                break;
+                            }
+
                             NSBMDTexture tex = Textures[texid];
                             mat.spdata = tex.spdata; //RITORNA QUI
                             mat.texdata = tex.texdata;
@@ -74,10 +86,10 @@ namespace LibNDSFormats.NSBMD {
                             break;
                         }
                     }
-                    if (m.Materials[m.Polygons[j].MatId].format != 7) {
+                    if (mat.format != 7) {
                         for (int k = 0; k < m.Palettes.Count; k++) {
-                            if (m.Palettes[k].palmatid.Contains((uint)m.Polygons[j].MatId)) {
-                                int palid = k;
+                            if (m.Palettes[k].palmatid.Contains((uint)matId)) {
+                                int palid = -1;
                                 for (int l = 0; l < Palettes.Count; l++) {
                                     if (Palettes[l].palname == m.Palettes[k].palname) {
                                         palid = l;
@@ -85,7 +97,11 @@ namespace LibNDSFormats.NSBMD {
                                     }
                                 }
 
-                                NSBMDMaterial mat = m.Materials[m.Polygons[j].MatId];
+                                if (palid < 0) {
+                                    MarkMissingExternalTexture(mat);
+                                    break;
+                                }
+
                                 NSBMDPalette pal = Palettes[palid];
 
                                 mat.paldata = pal.paldata;
@@ -99,6 +115,20 @@ namespace LibNDSFormats.NSBMD {
                 }
             }
 
+        }
+
+        private static void MarkMissingExternalTexture(NSBMDMaterial mat) {
+            mat.missingExternalTexture = true;
+            mat.format = 0;
+            mat.texdata = null;
+            mat.spdata = null;
+            mat.paldata = null;
+            mat.texname = String.Empty;
+            mat.palname = String.Empty;
+            mat.DiffuseColor = Color.White;
+            mat.AmbientColor = Color.White;
+            mat.SpecularColor = Color.White;
+            mat.EmissionColor = Color.White;
         }
 
         /// <summary>

--- a/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
+++ b/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
@@ -221,7 +221,11 @@ namespace LibNDSFormats.NSBMD {
                             continue;
                         }
 
-                        Gl.glBindTexture(Gl.GL_TEXTURE_2D, matid + 1 + matstart);
+						if (mat.missingExternalTexture || mat.format == 0) {
+							Gl.glBindTexture(Gl.GL_TEXTURE_2D, 0);
+						} else {
+							Gl.glBindTexture(Gl.GL_TEXTURE_2D, matid + 1 + matstart);
+						}
 
 						// Convert pixel coords to normalised STs
 						Gl.glMatrixMode(Gl.GL_TEXTURE);

--- a/DS_Map/LibNDSFormats/NSBMD/NSBMDMaterial.cs
+++ b/DS_Map/LibNDSFormats/NSBMD/NSBMDMaterial.cs
@@ -46,6 +46,7 @@ namespace LibNDSFormats.NSBMD
         public int Alpha;
         public bool diffuseColor;
 		public bool shine;
+        public bool missingExternalTexture;
         public float[] mtx = null;
 
         #endregion Fields 


### PR DESCRIPTION
- Clarifies that map/building texture selectors are preview-only
- Requires exact texture/palette name matches when applying NSBTX data
- Renders missing external texture matches as untextured/white, matching in-game behaviour
- Fixes #2 


https://github.com/user-attachments/assets/5c81ba1c-54aa-493c-9b86-54391add0be3

