### PR TITLE
Make Map Editor texture preview respect 1-30 alpha values for materials

### DIFF
--- a/.github/workflows/MrHamm-canary-build.yaml
+++ b/.github/workflows/MrHamm-canary-build.yaml
@@ -1,0 +1,118 @@
+name: MrHam's DSPRE Canary Build
+
+on:
+  push:
+    branches:
+      - main
+      - material-alpha-map-preview
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+env:
+  SOLUTION_FILE_PATH: DS_Map.sln
+  BUILD_CONFIGURATION: Release
+
+jobs:
+  build:
+    if: github.repository == 'DevHam88/DSPRE'
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Clone Database Repository
+      run: |
+        git clone https://github.com/DS-Pokemon-Rom-Editor/scrcmd-database.git databases
+
+    - name: Clone ds-rom Repository
+      run: |
+        git clone --depth 1 https://github.com/DS-Pokemon-Rom-Editor/ds-rom.git ds-rom
+
+    - name: Restore NuGet packages
+      working-directory: ${{ github.workspace }}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build DSPRE
+      working-directory: ${{ github.workspace }}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Build dsrom.exe
+      run: |
+        cargo build --release -p ds-rom-cli --manifest-path ds-rom/Cargo.toml
+        New-Item -ItemType Directory -Force -Path "${{ github.workspace }}\DS_Map\bin\Release\Tools" | Out-Null
+        Copy-Item -Path "${{ github.workspace }}\ds-rom\target\release\dsrom.exe" -Destination "${{ github.workspace }}\DS_Map\bin\Release\Tools\dsrom.exe" -Force
+
+    - name: Prepare Release Files
+      run: |
+        mkdir "${{ github.workspace }}\DS_Map\bin\Release\databases"
+        robocopy databases "${{ github.workspace }}\DS_Map\bin\Release\databases" /E /XD "databases\.git\objects\pack"
+        if ($LASTEXITCODE -le 7) { exit 0 } else { exit 1 }
+
+    - name: Set release metadata
+      id: release_metadata
+      shell: pwsh
+      run: |
+        if ("${{ github.ref_name }}" -eq "main") {
+          "tag=canary" >> $env:GITHUB_OUTPUT
+          "zip=DSPRE-MrHam-canary-${{ github.sha }}.zip" >> $env:GITHUB_OUTPUT
+          "name=MrHam's DSPRE Canary Build" >> $env:GITHUB_OUTPUT
+        } else {
+          "tag=canary-alpha-test" >> $env:GITHUB_OUTPUT
+          "zip=DSPRE-MrHam-alpha-test-${{ github.sha }}.zip" >> $env:GITHUB_OUTPUT
+          "name=MrHam's DSPRE Alpha Test Build" >> $env:GITHUB_OUTPUT
+        }
+
+    - name: Zip Release Files
+      run: Compress-Archive -Path "${{ github.workspace }}\DS_Map\bin\Release\*" -DestinationPath ${{ steps.release_metadata.outputs.zip }}
+
+    - name: Fetch tags
+      run: git fetch --prune --unshallow --tags
+
+    - name: Delete previous release
+      run: |
+        gh release delete --yes ${{ steps.release_metadata.outputs.tag }} || true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Update release tag
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git tag -f ${{ steps.release_metadata.outputs.tag }} -m "${{ steps.release_metadata.outputs.name }} for commit ${{ github.sha }}"
+        git push -f origin ${{ steps.release_metadata.outputs.tag }}
+
+    - name: Get current date
+      id: date
+      run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+    - name: Create new release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.release_metadata.outputs.tag }}
+        name: ${{ steps.release_metadata.outputs.name }} ${{ steps.date.outputs.date }} (${{ github.sha }})
+        files: ${{ steps.release_metadata.outputs.zip }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        body: |
+          ##  ⚠️ Canary Build Notice ⚠️
+          This is a Canary Build of DSPRE, meaning it is automatically generated from the latest pushed code. It includes the most recent changes, improvements, and experimental features, but may be unstable or contain bugs.
+
+          ## 🚧 What does this mean?
+          This build reflects ongoing development and is not a stable release.
+          Features may be incomplete, subject to change, or cause unexpected issues.
+          Use at your own risk—expect potential crashes, broken functionality, or unpolished features.
+
+          ## 💡 Who is this for?
+          Developers and testers who want to stay up-to-date with the latest progress.
+          Users willing to report issues and provide feedback on new changes.
+          If you're looking for a more reliable version, consider using the latest Stable Release instead.
+        prerelease: true
+        generate_release_notes: true

--- a/.github/workflows/MrHamm-canary-build.yaml
+++ b/.github/workflows/MrHamm-canary-build.yaml
@@ -2,10 +2,11 @@ name: MrHam's DSPRE Canary Build
 
 on:
   push:
-    branches:
-      - main
-      - material-alpha-map-preview
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref_name == 'main' && 'canary' || 'alpha' }}
+  cancel-in-progress: true
 
 permissions:
   contents: write

--- a/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
+++ b/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
@@ -111,23 +111,6 @@ namespace LibNDSFormats.NSBMD {
 			Translucent,
 			Picking
 		}
-		private static bool MaterialUsesTextureAlpha(NSBMDMaterial mat) {
-			return mat.format == 1 || mat.format == 6;
-		}
-
-		private static bool MaterialUsesMaterialAlpha(NSBMDMaterial mat) {
-			return mat.Alpha > 0 && mat.Alpha < 31;
-		}
-
-		private static bool ShouldRenderMaterialInPass(NSBMDMaterial mat, RenderMode r) {
-			if (mat.Alpha == 0) {
-				return false;
-			}
-
-			bool translucent = MaterialUsesTextureAlpha(mat) || MaterialUsesMaterialAlpha(mat);
-			return r == RenderMode.Translucent ? translucent : !translucent;
-		}
-
 		private static float MaterialAlpha(NSBMDMaterial mat) {
 			return mat.Alpha >= 31 ? 1.0f : mat.Alpha / 31.0f;
 		}
@@ -184,7 +167,6 @@ namespace LibNDSFormats.NSBMD {
 		public void RenderModel(string file2, MKDS_Course_Editor.NSBTA.NSBTA.NSBTA_File ani, int[] aniframeS, int[] aniframeT, int[] aniframeScaleS, int[] aniframeScaleT, int[] aniframeR, MKDS_Course_Editor.NSBCA.NSBCA.NSBCA_File ca, RenderMode r, bool anim, bool anim2, int selectedanim, float X, float Y, float dist, float elev, float ang, bool licht, MKDS_Course_Editor.NSBTP.NSBTP.NSBTP_File p, NSBMD nsb) {
 			file = file2;
 			int light = Gl.glIsEnabled(Gl.GL_LIGHTING);
-			Gl.glDepthMask(r == RenderMode.Translucent ? Gl.GL_FALSE : Gl.GL_TRUE);
 			Gl.glDisable(Gl.GL_LIGHTING);
 			Gl.glLineWidth(2.0F);
 
@@ -235,9 +217,13 @@ namespace LibNDSFormats.NSBMD {
 							mattt.Add(matt[matid]);
 						}
 						NSBMDMaterial mat = Model.Materials[matid];
-						if (!ShouldRenderMaterialInPass(mat, r)) {
-							continue;
-						}
+						if ((mat.format == 0 || (mat.format >= 2 && mat.format <= 5) || mat.format == 7) && r != RenderMode.Opaque) {
+                            continue;
+                        }
+
+						if ((mat.format == 1 || mat.format == 6) && r == RenderMode.Translucent) {
+                            continue;
+                        }
 
                         Gl.glBindTexture(Gl.GL_TEXTURE_2D, matid + 1 + matstart);
 
@@ -482,15 +468,13 @@ namespace LibNDSFormats.NSBMD {
 				}
 				stackID = poly.StackID; // the first matrix used by this polygon
 
-                try {
+				try {
                     Process3DCommand(poly.PolyData, Model.Materials[poly.MatId], poly.JointID, true);
                 } catch {
 					Console.WriteLine($"Invalid MatID {poly.MatId}! Could not read model [file: {file}]");
-					Gl.glDepthMask(Gl.GL_TRUE);
 					return;
 				}
             }
-			Gl.glDepthMask(Gl.GL_TRUE);
 			writevertex = false;
 		}
 		/// <summary>

--- a/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
+++ b/DS_Map/LibNDSFormats/NSBMD/NSBMDGlRenderer.cs
@@ -111,6 +111,27 @@ namespace LibNDSFormats.NSBMD {
 			Translucent,
 			Picking
 		}
+		private static bool MaterialUsesTextureAlpha(NSBMDMaterial mat) {
+			return mat.format == 1 || mat.format == 6;
+		}
+
+		private static bool MaterialUsesMaterialAlpha(NSBMDMaterial mat) {
+			return mat.Alpha > 0 && mat.Alpha < 31;
+		}
+
+		private static bool ShouldRenderMaterialInPass(NSBMDMaterial mat, RenderMode r) {
+			if (mat.Alpha == 0) {
+				return false;
+			}
+
+			bool translucent = MaterialUsesTextureAlpha(mat) || MaterialUsesMaterialAlpha(mat);
+			return r == RenderMode.Translucent ? translucent : !translucent;
+		}
+
+		private static float MaterialAlpha(NSBMDMaterial mat) {
+			return mat.Alpha >= 31 ? 1.0f : mat.Alpha / 31.0f;
+		}
+
 		public static float[] Rotate(float[] a, float x, float y, float z) {
 			float[] b = loadIdentity();
 			float cx = (float)Math.Cos(x);
@@ -163,6 +184,7 @@ namespace LibNDSFormats.NSBMD {
 		public void RenderModel(string file2, MKDS_Course_Editor.NSBTA.NSBTA.NSBTA_File ani, int[] aniframeS, int[] aniframeT, int[] aniframeScaleS, int[] aniframeScaleT, int[] aniframeR, MKDS_Course_Editor.NSBCA.NSBCA.NSBCA_File ca, RenderMode r, bool anim, bool anim2, int selectedanim, float X, float Y, float dist, float elev, float ang, bool licht, MKDS_Course_Editor.NSBTP.NSBTP.NSBTP_File p, NSBMD nsb) {
 			file = file2;
 			int light = Gl.glIsEnabled(Gl.GL_LIGHTING);
+			Gl.glDepthMask(r == RenderMode.Translucent ? Gl.GL_FALSE : Gl.GL_TRUE);
 			Gl.glDisable(Gl.GL_LIGHTING);
 			Gl.glLineWidth(2.0F);
 
@@ -213,13 +235,9 @@ namespace LibNDSFormats.NSBMD {
 							mattt.Add(matt[matid]);
 						}
 						NSBMDMaterial mat = Model.Materials[matid];
-						if ((mat.format == 0 || (mat.format >= 2 && mat.format <= 5) || mat.format == 7) && r != RenderMode.Opaque) {
-                            continue;
-                        }
-
-						if ((mat.format == 1 || mat.format == 6) && r == RenderMode.Translucent) {
-                            continue;
-                        }
+						if (!ShouldRenderMaterialInPass(mat, r)) {
+							continue;
+						}
 
                         Gl.glBindTexture(Gl.GL_TEXTURE_2D, matid + 1 + matstart);
 
@@ -342,7 +360,8 @@ namespace LibNDSFormats.NSBMD {
 						}
 						Gl.glEnable(Gl.GL_ALPHA_TEST);
 						Gl.glAlphaFunc(Gl.GL_GREATER, 0f);
-						Gl.glColor4f(0xff, 0xff, 0xff, 0xff);
+						float materialAlpha = MaterialAlpha(mat);
+						Gl.glColor4f(1.0f, 1.0f, 1.0f, materialAlpha);
 
 						if (licht && (((mat.PolyAttrib >> 0) & 0x1) == 0 && ((mat.PolyAttrib >> 1) & 0x1) == 0 && ((mat.PolyAttrib >> 2) & 0x1) == 0 && ((mat.PolyAttrib >> 3) & 0x1) == 0) == false) {
 							//Gl.glLightfv(Gl.GL_LIGHT0, Gl.GL_POSITION, new float[] { 1, 1, 1, 0 });
@@ -391,7 +410,7 @@ namespace LibNDSFormats.NSBMD {
 							}
 
 							if (mat.diffuseColor) {
-								Gl.glColor4f((float)mat.DiffuseColor.R / 255f, (float)mat.DiffuseColor.G / 255f, (float)mat.DiffuseColor.B / 255f, (float)mat.DiffuseColor.A / 255f);
+								Gl.glColor4f((float)mat.DiffuseColor.R / 255f, (float)mat.DiffuseColor.G / 255f, (float)mat.DiffuseColor.B / 255f, materialAlpha);
 							}
 
 						} else {
@@ -402,7 +421,7 @@ namespace LibNDSFormats.NSBMD {
 							Gl.glDisable(Gl.GL_LIGHT3);
 
 							if (mat.diffuseColor) {
-								Gl.glColor4f((float)mat.DiffuseColor.R / 255f, (float)mat.DiffuseColor.G / 255f, (float)mat.DiffuseColor.B / 255f, (float)mat.DiffuseColor.A / 255f);
+								Gl.glColor4f((float)mat.DiffuseColor.R / 255f, (float)mat.DiffuseColor.G / 255f, (float)mat.DiffuseColor.B / 255f, materialAlpha);
 							}
 
 						}
@@ -463,13 +482,15 @@ namespace LibNDSFormats.NSBMD {
 				}
 				stackID = poly.StackID; // the first matrix used by this polygon
 
-				try {
+                try {
                     Process3DCommand(poly.PolyData, Model.Materials[poly.MatId], poly.JointID, true);
                 } catch {
 					Console.WriteLine($"Invalid MatID {poly.MatId}! Could not read model [file: {file}]");
+					Gl.glDepthMask(Gl.GL_TRUE);
 					return;
 				}
             }
+			Gl.glDepthMask(Gl.GL_TRUE);
 			writevertex = false;
 		}
 		/// <summary>


### PR DESCRIPTION
Makes the Map Editor preview respect NSBMD material alpha values, so semi-transparent elements render more faithfully in preview.

This fixes many cases, where house/signpost shadows rendered as solid black instead of translucent, or the translucent tiles on puddles.

- Applies `NSBMDMaterial.Alpha` when rendering model materials.
- Keeps existing render-pass behaviour unchanged to preserve building placement/scaling.
- Preview-only change; does not affect ROM data or Map BIN saving.

Tested in HeartGold (e.g. New Bark Town)

- House/signpost shadows (Colour4, reduced alpha) now render translucent.
- Windmill shadows (A3I5) still render correctly.
- Buildings remain correctly positioned and scaled.

## Apology from a novice

Sorry, this is currently stacked on PR #208 because that earlier Map Editor preview PR has not been reviewed/merged yet, I didn't conceive of doing two attempts at changes, so it didn't occur to me to make a branch for the first change.

---

<img width="1245" height="879" alt="alpha-value-translucency-not-rendering" src="https://github.com/user-attachments/assets/9929f23a-b5cd-48a3-845b-e799b5d25df3" />
<img width="1237" height="875" alt="alpha-value-translucency-correctly-rendering" src="https://github.com/user-attachments/assets/5c9b037f-94e9-4dc3-bdac-1f22bee6db5a" />