### PR TITLE
Trim Action lines when exporting .script files

### DIFF
--- a/DS_Map/ROMFiles/ScriptFile.cs
+++ b/DS_Map/ROMFiles/ScriptFile.cs
@@ -1523,7 +1523,7 @@ namespace DSPRE.ROMFiles
 
             for (int l = 0; l < linelist.Count; l++)
             {
-                string cur = linelist[l];
+                string cur = linelist[l].Trim();
                 if (!string.IsNullOrWhiteSpace(cur))
                 {
                     lineSource.Add((l, cur));


### PR DESCRIPTION
Building a ROM currently always adds a new tab space before each action command line when updating `.script` files, increasing the padding on every build.

<img width="1179" height="669" alt="image" src="https://github.com/user-attachments/assets/55ef70d1-4f9a-4467-ac12-a1bfa06c55d5" />

This is dealt with using `PreprocessLines()` for both Scripts and Functions, but not Actions for some reason.